### PR TITLE
Completed the new implementation of CycleDecomposition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+smallvec = "1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-use std::{collections::VecDeque, ops::Mul};
+use std::ops::Mul;
+
+use smallvec::SmallVec;
 
 /// Represents a permutation as a table, where a permutation
 /// is a bijective function from \[n\] to \[n\], where \[n\] = {0, 1, ... n}.
@@ -12,6 +14,24 @@ use std::{collections::VecDeque, ops::Mul};
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Table<const N: usize> {
     table: [usize; N],
+}
+
+impl<const N: usize> Table<N> {
+    pub fn identity() -> Self {
+        let mut table = Table { table: [0; N] };
+        for i in 0..N {
+            table.table[i] = i;
+        }
+        table
+    }
+
+    pub fn cycle() -> Self {
+        let mut table = Table { table: [0; N] };
+        for i in 0..N {
+            table.table[i] = (i + 1 + N) % N;
+        }
+        table
+    }
 }
 
 impl<const N: usize> Mul for Table<N> {
@@ -29,11 +49,12 @@ impl<const N: usize> Mul for Table<N> {
 impl<const N: usize> From<&CycleDecomposition<N>> for Table<N> {
     fn from(cycles: &CycleDecomposition<N>) -> Self {
         let mut table = Table { table: [0; N] };
-        for cycle in cycles.cycles.iter() {
+        for cycle in cycles {
             for (i, j) in cycle
+                .cycle_slice
                 .iter()
                 .copied()
-                .zip(cycle.iter().copied().cycle().skip(1))
+                .zip(cycle.cycle_slice.iter().copied().cycle().skip(1))
             {
                 table.table[i] = j;
             }
@@ -59,15 +80,99 @@ impl<const N: usize> From<&CycleDecomposition<N>> for Table<N> {
 /// ```text
 /// (0 1 3) (2)
 /// ```
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug)]
 pub struct CycleDecomposition<const N: usize> {
-    cycles: Box<[Box<[usize]>]>,
+    enumeration: [usize; N],
+    starts: SmallVec<[usize; 5]>,
+}
+
+impl<const N: usize> CycleDecomposition<N> {
+    pub fn normalize(&mut self) {
+        todo!()
+    }
+}
+
+/// A view into a particular cycle of a [`CycleDecomposition`].
+pub struct Cycle<'a, const N: usize> {
+    cycle_slice: &'a [usize],
+}
+
+/// An owned version of a [`Cycle`].
+pub struct OwnedCycle<const N: usize> {
+    cycle: Vec<usize>,
+}
+
+impl<'a, const N: usize> From<&'a OwnedCycle<N>> for Cycle<'a, N> {
+    fn from(owned_cycle: &'a OwnedCycle<N>) -> Self {
+        Cycle {
+            cycle_slice: owned_cycle.cycle.as_slice(),
+        }
+    }
+}
+
+impl<'a, const N: usize> From<Cycle<'a, N>> for OwnedCycle<N> {
+    fn from(cycle: Cycle<'a, N>) -> Self {
+        OwnedCycle {
+            cycle: cycle.cycle_slice.to_vec(),
+        }
+    }
+}
+
+impl<'a, const N: usize> Cycle<'a, N> {
+    pub fn len(&self) -> usize {
+        self.cycle_slice.len()
+    }
+}
+
+pub struct CycleIter<'a, const N: usize> {
+    decomposition: &'a CycleDecomposition<N>,
+    cycle: usize,
+}
+
+impl<'a, const N: usize> Iterator for CycleIter<'a, N> {
+    type Item = Cycle<'a, N>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let n = self.decomposition.starts.len();
+
+        if self.cycle >= n {
+            return None;
+        }
+
+        self.cycle += 1;
+
+        let right_endpoint = if self.cycle >= self.decomposition.starts.len() {
+            N
+        } else {
+            self.decomposition.starts[self.cycle]
+        };
+
+        let next_cycle = Some(Cycle {
+            cycle_slice: &self.decomposition.enumeration
+                [self.decomposition.starts[self.cycle - 1]..right_endpoint],
+        });
+
+        next_cycle
+    }
+}
+
+impl<'a, const N: usize> IntoIterator for &'a CycleDecomposition<N> {
+    type Item = Cycle<'a, N>;
+
+    type IntoIter = CycleIter<'a, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CycleIter {
+            decomposition: &self,
+            cycle: 0,
+        }
+    }
 }
 
 impl<const N: usize> CycleDecomposition<N> {
     pub fn cycle_type(&self) -> CycleType<N> {
         let mut cycle_type = [0; N];
-        for cycle in self.cycles.iter() {
+        for cycle in self {
             cycle_type[cycle.len() - 1] += 1;
         }
         CycleType { cycle_type }
@@ -113,68 +218,32 @@ impl<const N: usize> CycleType<N> {
 
 impl<const N: usize> From<&Table<N>> for CycleDecomposition<N> {
     fn from(table: &Table<N>) -> CycleDecomposition<N> {
-        let mut included = [false; N];
-        let mut tmp_cycles = Vec::new();
+        let mut i = 0;
+        let mut enumeration = [0; N];
+        let mut starts: SmallVec<[usize; 5]> = SmallVec::new();
+        // TODO Replace with bitvec. Tried once but I had problems using N.
+        let mut used = [false; N];
         loop {
-            if let Some(i) = included
-                .iter()
-                .enumerate()
-                .fold(None, |acc, (i, b)| match acc {
-                    Some(_) => acc,
-                    None => {
-                        if !*b {
-                            Some(i)
-                        } else {
-                            None
-                        }
-                    }
-                })
-            {
-                let mut cycle = VecDeque::new();
-                let mut j = table.table[i];
-                included[i] = true;
-                cycle.push_back(i);
+            if let Some((next_unused_index, _)) = used.iter().enumerate().find(|(_i, e)| !*e) {
+                let mut j = next_unused_index;
+                starts.extend(std::iter::once(i));
                 loop {
-                    if j == i {
-                        tmp_cycles.push(cycle);
+                    used[j] = true;
+                    enumeration[i] = table.table[j];
+                    i += 1;
+                    j = table.table[j];
+                    if j == next_unused_index {
                         break;
-                    } else {
-                        cycle.push_back(j);
-                        included[j] = true;
-                        j = table.table[j];
                     }
                 }
             } else {
                 break;
             }
         }
-        fn normalize(v: &VecDeque<usize>) -> Box<[usize]> {
-            if let Some((highest, _)) = v
-                .iter()
-                .enumerate()
-                .max_by_key(|(_highest_index, highest_value)| *highest_value)
-            {
-                let mut b = vec![0; v.len()];
-                let n = v.len();
-                let mut i: usize = highest;
-                loop {
-                    b[(n + i - highest) % n] = v[i % n];
-                    i = (i + 1) % n;
-                    if i == highest {
-                        break;
-                    }
-                }
-                b.into_boxed_slice()
-            } else {
-                panic!("no no no no no");
-            }
+        CycleDecomposition {
+            enumeration,
+            starts,
         }
-        let n_cycles = tmp_cycles.len();
-        let cycles = (0..n_cycles)
-            .map(|i| normalize(&tmp_cycles[i]))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        CycleDecomposition { cycles }
     }
 }
 
@@ -183,30 +252,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cycles_from_table() {
-        let table: Table<3> = Table { table: [1, 2, 0] };
-        let cycles: CycleDecomposition<3> = CycleDecomposition {
-            cycles: vec![vec![2, 0, 1].into_boxed_slice()].into_boxed_slice(),
-        };
-        assert_eq!(CycleDecomposition::from(&table), cycles);
+    fn back_n_forth() {
+        let table: Table<3> = Table::cycle();
+        let cycle_decomposition_from_table: CycleDecomposition<3> = (&table).into();
+        let table_from_cycle_decomposition_from_table = (&cycle_decomposition_from_table).into();
 
-        assert_eq!(table, Table::from(&cycles));
-
-        assert_eq!(cycles.cycle_type().as_slice(), &[0, 0, 1]);
-
-        let table: Table<3> = Table { table: [0, 1, 2] };
-        let cycles: CycleDecomposition<3> = CycleDecomposition {
-            cycles: vec![
-                vec![0].into_boxed_slice(),
-                vec![1].into_boxed_slice(),
-                vec![2].into_boxed_slice(),
-            ]
-            .into_boxed_slice(),
-        };
-        assert_eq!(CycleDecomposition::from(&table), cycles);
-
-        assert_eq!(table, Table::from(&cycles));
-
-        assert_eq!(cycles.cycle_type().as_slice(), &[3, 0, 0]);
+        assert_eq!(table, table_from_cycle_decomposition_from_table);
     }
 }


### PR DESCRIPTION
This implementation flattens the representation so that it can be pulled into cache all at once. In particular, for small cycles (up to 5 length), the entire cycle can be in one memory location on the stack. 5 may not be the right number here, and you might want to tune that for your application. Not sure if I'll expose that.